### PR TITLE
add binary event support to the xml mapper.

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/map/xml/sourcemapper/XmlSourceMapper.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/map/xml/sourcemapper/XmlSourceMapper.java
@@ -279,21 +279,22 @@ public class XmlSourceMapper extends SourceMapper {
         } else if (eventObject instanceof OMElement) {
             rootOMElement = (OMElement) eventObject;
         } else if (eventObject instanceof byte[]) {
+            String events = null;
             try {
-                String events = new String((byte[]) eventObject, "UTF-8");
+                events = new String((byte[]) eventObject, "UTF-8");
                 rootOMElement = AXIOMUtil.stringToOM(events);
             } catch (UnsupportedEncodingException e) {
                 log.error("Error is encountered while decoding the byte stream. Please note that only UTF-8 "
                         + "encoding is supported" + e.getMessage(), e);
                 return new Event[0];
             } catch (XMLStreamException | DeferredParsingException e) {
-                log.warn("Error parsing incoming XML event : " + eventObject + ". Reason: " + e.getMessage() +
+                log.warn("Error parsing incoming XML event : " + events + ". Reason: " + e.getMessage() +
                         ". Hence dropping message chunk");
                 return new Event[0];
             }
         } else {
-            log.warn("Event object is invalid. Expected String/OMElement, but found " + eventObject.getClass()
-                    .getCanonicalName());
+            log.warn("Event object is invalid. Expected String/OMElement or Byte Array, but found "
+                    + eventObject.getClass().getCanonicalName());
             return new Event[0];
         }
 

--- a/component/src/main/java/org/wso2/extension/siddhi/map/xml/sourcemapper/XmlSourceMapper.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/map/xml/sourcemapper/XmlSourceMapper.java
@@ -41,6 +41,7 @@ import org.wso2.siddhi.query.api.definition.Attribute;
 import org.wso2.siddhi.query.api.definition.StreamDefinition;
 import org.wso2.siddhi.query.api.exception.SiddhiAppValidationException;
 
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -228,7 +229,7 @@ public class XmlSourceMapper extends SourceMapper {
     }
 
     @Override public Class[] getSupportedInputEventClasses() {
-        return new Class[]{String.class, OMElement.class};
+        return new Class[]{String.class, OMElement.class, byte[].class};
     }
 
     /**
@@ -265,22 +266,37 @@ public class XmlSourceMapper extends SourceMapper {
      */
     private Event[] convertToEvents(Object eventObject) {
         List<Event> eventList = new ArrayList<>();
+
         OMElement rootOMElement;
         if (eventObject instanceof String) {
             try {
                 rootOMElement = AXIOMUtil.stringToOM((String) eventObject);
             } catch (XMLStreamException | DeferredParsingException e) {
-                log.warn("Error parsing incoming XML event : " + eventObject + ". Reason: " + e.getMessage() +
-                        ". Hence dropping message chunk");
+                log.warn("Error parsing incoming XML event : " + eventObject + ". Reason: " + e.getMessage()
+                        + ". Hence dropping message chunk");
                 return new Event[0];
             }
         } else if (eventObject instanceof OMElement) {
             rootOMElement = (OMElement) eventObject;
+        } else if (eventObject instanceof byte[]) {
+            try {
+                String events = new String((byte[]) eventObject, "UTF-8");
+                rootOMElement = AXIOMUtil.stringToOM(events);
+            } catch (UnsupportedEncodingException e) {
+                log.error("Error is encountered while decoding the byte stream. Please note that only UTF-8 "
+                        + "encoding is supported" + e.getMessage(), e);
+                return new Event[0];
+            } catch (XMLStreamException | DeferredParsingException e) {
+                log.warn("Error parsing incoming XML event : " + eventObject + ". Reason: " + e.getMessage() +
+                        ". Hence dropping message chunk");
+                return new Event[0];
+            }
         } else {
-            log.warn("Event object is invalid. Expected String/OMElement, but found " +
-                    eventObject.getClass().getCanonicalName());
+            log.warn("Event object is invalid. Expected String/OMElement, but found " + eventObject.getClass()
+                    .getCanonicalName());
             return new Event[0];
         }
+
         if (isCustomMappingEnabled) {   //custom mapping case
             if (enclosingElementSelectorPath != null) {  //has multiple events
                 List enclosingNodeList;

--- a/component/src/test/java/org/wso2/extension/siddhi/map/xml/sourcemapper/XmlSourceMapperTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/map/xml/sourcemapper/XmlSourceMapperTestCase.java
@@ -29,8 +29,10 @@ import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
 import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
 import org.wso2.siddhi.core.stream.output.StreamCallback;
 import org.wso2.siddhi.core.util.EventPrinter;
+import org.wso2.siddhi.core.util.SiddhiTestHelper;
 import org.wso2.siddhi.core.util.transport.InMemoryBroker;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class XmlSourceMapperTestCase {
@@ -212,6 +214,57 @@ public class XmlSourceMapperTestCase {
 
         //assert event count
         AssertJUnit.assertEquals("Number of events", 0, count.get());
+        executionPlanRuntime.shutdown();
+        siddhiManager.shutdown();
+    }
+
+    @Test
+    public void testXmlInputMappingDefaultMultipleEventsOnBinaryMessage() throws InterruptedException {
+        log.info("Test case for xml input mapping with default mapping for multiple events");
+
+        String streams = "" +
+                "@App:name('TestSiddhiApp')" +
+                "@source(type='inMemory', topic='stock', @map(type='xml')) " +
+                "define stream FooStream (symbol string, price float, volume long); " +
+                "define stream BarStream (symbol string, price float, volume long); ";
+
+        String query = "" +
+                "from FooStream " +
+                "select * " +
+                "insert into BarStream; ";
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        executionPlanRuntime.addCallback("BarStream", new StreamCallback() {
+
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                for (Event event : events) {
+                    switch (count.incrementAndGet()) {
+                    case 1:
+                        org.junit.Assert.assertEquals(55.6f, event.getData(1));
+                        break;
+                    case 2:
+                        org.junit.Assert.assertEquals(75.6f, event.getData(1));
+                        break;
+                    default:
+                        org.junit.Assert.fail();
+                    }
+                }
+            }
+        });
+
+        String events =  "<events><event><symbol>WSO2</symbol><price>55.6</price>" +
+                "<volume>100</volume></event><event><symbol>IBM</symbol><price>75.6</price>" +
+                "<volume>10</volume></event><event111><symbol>IBM</symbol><price>75.6</price>"
+                + "<volume>10</volume></event111></events>";
+        executionPlanRuntime.start();
+        InMemoryBroker.publish("stock", events.getBytes(StandardCharsets.UTF_8));
+        SiddhiTestHelper.waitForEvents(50, 2, count, 2000);
+        //assert event count
+        AssertJUnit.assertEquals("Number of events", 2, count.get());
         executionPlanRuntime.shutdown();
         siddhiManager.shutdown();
     }
@@ -1034,7 +1087,7 @@ public class XmlSourceMapperTestCase {
     }
 
     @Test
-    public void testXmlInputMappingCustomForEvents() throws InterruptedException {
+    public void testXmlInputMappingCustomForEvents15() throws InterruptedException {
         log.info("Test case for if elementObj instanceof OMAttribute but some problem occurred during convert data.");
         log = Logger.getLogger(XmlSourceMapper.class);
         UnitTestAppender appender = new UnitTestAppender();
@@ -1073,7 +1126,7 @@ public class XmlSourceMapperTestCase {
     }
 
     @Test(expectedExceptions = SiddhiAppRuntimeException.class)
-    public void testXmlInputMappingCustom123() throws InterruptedException {
+    public void testXmlInputMappingCustom16() throws InterruptedException {
         log.info("Test case for enclosing Element XPath.");
 
         String streams = "" +
@@ -1093,5 +1146,70 @@ public class XmlSourceMapperTestCase {
 
         SiddhiManager siddhiManager = new SiddhiManager();
         siddhiManager.createSiddhiAppRuntime(streams + query);
+    }
+
+    @Test
+    public void testXmlInputMappingCustomOnBinaryMessage17() throws InterruptedException {
+        log.info("Verify xml mapping when multiple enclosing tags are present");
+
+        String streams = "" +
+                "@App:name('TestSiddhiApp')" +
+                "@source(type='inMemory', topic='stock', @map(type='xml', namespaces = " +
+                "\"dt=urn:schemas-microsoft-com:datatypes\", " +
+                "enclosing.element=\"//portfolio\", @attributes(symbol = \"symbol\"" +
+                "                                           , price = \"price\"" +
+                "                                           , volume = \"volume\"))) " +
+                "define stream FooStream (symbol string, price float, volume long); " +
+                "define stream BarStream (symbol string, price float, volume long); ";
+
+        String query = "" +
+                "from FooStream " +
+                "select * " +
+                "insert into BarStream; ";
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime executionPlanRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+
+        executionPlanRuntime.addCallback("BarStream", new StreamCallback() {
+
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                for (Event event : events) {
+                    switch (count.incrementAndGet()) {
+                    case 1:
+                        org.junit.Assert.assertEquals(55.6f, event.getData(1));
+                        break;
+                    case 2:
+                        org.junit.Assert.assertEquals(75.6f, event.getData(1));
+                        break;
+                    default:
+                        org.junit.Assert.fail();
+                    }
+                }
+            }
+        });
+        executionPlanRuntime.start();
+        InMemoryBroker.publish("stock", ("<?xml version=\"1.0\"?>" +
+                "<root>" +
+                "<portfolio xmlns:dt=\"urn:schemas-microsoft-com:datatypes\">" +
+                "  <stock exchange=\"nasdaq\">" +
+                "    <volume>55</volume>" +
+                "    <symbol>WSO2</symbol>" +
+                "    <price>55.6</price>" +
+                "  </stock>" +
+                "</portfolio>" +
+                "<portfolio xmlns:dt=\"urn:schemas-microsoft-com:datatypes\">" +
+                "  <stock exchange=\"nyse\">" +
+                "    <volume>200</volume>" +
+                "    <symbol>IBM</symbol>" +
+                "    <price>75.6</price>" +
+                "  </stock>" +
+                "</portfolio>" +
+                "</root>").getBytes(StandardCharsets.UTF_8));
+        //assert event count
+        AssertJUnit.assertEquals("Number of events", 2, count.get());
+        executionPlanRuntime.shutdown();
+        siddhiManager.shutdown();
     }
 }


### PR DESCRIPTION
## Purpose
> Add binary event support to the xml mapper.

## Approach
> Convert byte array of events to the string and pass to the xml mapper.

## Automation tests
 - Unit tests 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes